### PR TITLE
Handle absolute and relative paths for model folder

### DIFF
--- a/docs/Basic Usage.md
+++ b/docs/Basic Usage.md
@@ -25,7 +25,7 @@ Once this is done, it should automatically redirect you to the main interface.
 ## Configuring
 
 If you have pre-existing Stable Diffusion files, you'll want to configure settings a bit. If not, the defaults are probably fine.
-- If you have an Auto WebUI or ComfyUI folder with models in it, go to the `Server` tab then `Server Configuration` and set `ModelRoot` to your UI's `models` dir, and `SDModelPath` to `Stable-diffusion` for Auto WebUI or `checkpoints` for ComfyUI.
+- If you have an Auto WebUI or ComfyUI folder with models in it, go to the `Server` tab then `Server Configuration` and set `ModelRoot` to the path to your UI's `models` dir, and set `SDModelFolder` to `Stable-diffusion` for Auto WebUI or `checkpoints` for ComfyUI.
 - Be sure to click the 'Save' button at the bottom when you're done (only visible if you've edited any settings)
 
 ![img](/docs/images/servermodelpath.png)

--- a/src/Core/Program.cs
+++ b/src/Core/Program.cs
@@ -85,7 +85,15 @@ public class Program
             Logs.Error($"Command line arguments given are invalid: {ex.Message}");
             return;
         }
-        Directory.CreateDirectory(ServerSettings.Paths.SDModelFullPath);
+        try
+        {
+            Directory.CreateDirectory(ServerSettings.Paths.SDModelFullPath);
+        }
+        catch (IOException ex)
+        {
+            Logs.Error($"Failed to create directory for SD models. You may need to check your ModelRoot and SDModelFolder settings. {ex.Message}");
+            return;
+        }
         RunOnAllExtensions(e => e.OnPreInit());
         Logs.Init("Prepping options...");
         T2IModels = new();

--- a/src/Core/Settings.cs
+++ b/src/Core/Settings.cs
@@ -59,14 +59,38 @@ public class Settings : AutoConfiguration
     /// <summary>Settings related to file paths.</summary>
     public class PathsData : AutoConfiguration
     {
-        [ConfigComment("Root path for model files. Defaults to 'Models'")]
+        [ConfigComment("Root path for model files. Use a full-formed path (starting with '/' or a Windows drive like 'C:') to use an absolute path. Defaults to 'Models'.")]
         public string ModelRoot = "Models";
 
-        [ConfigComment("The model folder to use within 'ModelRoot'. Use a full-formed path (starting with '/' or a Windows drive like 'C:') to use an absolute path. Defaults to 'Stable-Diffusion'.")]
+        [ConfigComment("The model folder to use within 'ModelRoot'. Defaults to 'Stable-Diffusion'.")]
         public string SDModelFolder = "Stable-Diffusion";
 
         /// <summary>(Getter) Path for Stable Diffusion models.</summary>
-        public string SDModelFullPath => SDModelFolder.StartsWith('/') || (SDModelFolder.Length > 2 && SDModelFolder[1] == ':') ? SDModelFolder : $"{Environment.CurrentDirectory}/{ModelRoot}/{SDModelFolder}";
+        public string SDModelFullPath
+        {
+            get
+            {
+                bool modelRootIsAbsolute = (ModelRoot.StartsWith('/') || (ModelRoot.Length > 2 && ModelRoot[1] == ':'));
+                bool sdFolderIsAbsolute = (SDModelFolder.StartsWith('/') || (SDModelFolder.Length > 2 && SDModelFolder[1] == ':'));
+
+                if (modelRootIsAbsolute && sdFolderIsAbsolute)
+                {
+                    return $"{SDModelFolder}";
+                }
+                else if (!modelRootIsAbsolute && sdFolderIsAbsolute)
+                {
+                    return $"{SDModelFolder}";
+                }
+                else if (modelRootIsAbsolute && !sdFolderIsAbsolute)
+                {
+                    return $"{ModelRoot}/{SDModelFolder}";
+                }
+                else
+                {
+                    return $"{Environment.CurrentDirectory}/{ModelRoot}/{SDModelFolder}";
+                }
+            }
+        }
 
         [ConfigComment("Root path for data (user configs, etc). Defaults to 'Data'")]
         public string DataPath = "Data";


### PR DESCRIPTION
Fix Issue https://github.com/Stability-AI/StableSwarmUI/issues/12 by allowing either the `SDModelFolder` setting or the `ModelRoot` setting to be an absolute path. If `SDModelFolder` is absolute, then `ModelRoot` is ignored.