### PR TITLE
Update README.md with macOS installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,19 @@ Key feature targets not yet implemented:
 
 # Installing on Mac
 
-- Install dotnet: `brew install dotnet`
+> **Note**: You can only run StableSwarmUI on Mac computers with M1 or M2 (Mx) Apple silicon processors.
 
-(TODO): somebody with Mac experience needs to fill this in. Probably similar to Linux. See also [issue #7](https://github.com/Stability-AI/StableSwarmUI/issues/7).
+1. Open Terminal.
+2. Ensure your `brew` packages are updated with `brew update`.
+3. Verify your `brew` installation with `brew doctor`. You should not see any error in the command output.
+4. Install .NET for macOS: `brew install dotnet`.
+5. Change the directory (`cd`) to the folder where you want to install StableSwarmUI.
+6. Clone the StableSwarmUI GitHub repository: `git clone https://github.com/Stability-AI/StableSwarmUI`.
+7. `cd StableSwarmUI` and run the installation script: `./launch-macos.sh`.
+
+The installation starts now and downloads the Stable Diffusion models from the internet. Depending on your internet connection, this may take several minutes. Wait for your web browser to open the StableSwarmUI window.
+
+> **Important**: During the StableSwarmUI installation, you are prompted for the type of backend you want to use. For Mac computers with M1 or M2, you can safely choose the ComfyUI backend and choose the Stable Diffusion XLD Base and Refiner models in the Download Models screen.
 
 # Documentation
 

--- a/launch-macos.sh
+++ b/launch-macos.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Ensure correct local path.
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd $SCRIPT_DIR
+
+# Building first is more reliable than running directly from src
+dotnet build src/StableSwarmUI.csproj --configuration Release -o ./src/bin/live_release
+# Default env configuration, gets overwritten by the C# code's settings handler
+ASPNETCORE_ENVIRONMENT="Production"
+ASPNETCORE_URLS="http://*:7801"
+# Actual runner.
+dotnet src/bin/live_release/StableSwarmUI.dll $@


### PR DESCRIPTION
Adds a section for M1 or M2 Mac computers with step-by-step instructions to install StableSwarmUl on macOS.

The `launch-macos.sh` script is the same as the 'launch-linux.sh' script and is included in a different PR.

This procedure has been tested on an M1 Mac computer with macOS 'Ventura' 13.4.1 (c)