### PR TITLE
Don't crash if comfy directories exist

### DIFF
--- a/launchtools/comfy-install-linux.sh
+++ b/launchtools/comfy-install-linux.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-mkdir dlbackend
+ComfyDirectory=ComfyUI
 
+mkdir -p dlbackend
 cd dlbackend
 
-git clone https://github.com/comfyanonymous/ComfyUI
-
-cd ComfyUI
+[ -d $ComfyDirectory ] && rm -rf $ComfyDirectory
+git clone https://github.com/comfyanonymous/ComfyUI $ComfyDirectory
+cd $ComfyDirectory
 
 python3 -m venv venv
 


### PR DESCRIPTION
Currently the `comfy-install-linux.sh` script and fatal errors if the directory exists. This is likely to happen when doing installs and reinstalls:

```
mkdir: dlbackend: File exists
fatal: destination path 'ComfyUI' already exists and is not an empty directory.
```

The new code uses `mkdir -p` which will exit 0 even if the `dlbackend` directory already exists. We could optionally wipe it.. but why not save some bandwidth on reinstalls and avoid re-downloading models?

It also does a simple directory check to see if the ComfyUI directory exists for the repo. If it does, it deletes it to be safe because using `git pull` instead can bring a whole host of merging conflicts, divergent branches, and other git nightmares.

:warning: It's best to start fresh, but in the future some folks might want to customize their Comfy repo codebase and prefer not having it wiped when reinstalling, so this might warrant caution in review.