### PR TITLE
Make backend visibility check work on all browsers

### DIFF
--- a/src/wwwroot/js/backends.js
+++ b/src/wwwroot/js/backends.js
@@ -160,9 +160,20 @@ let backendsListView = document.getElementById('backends_list');
 let backendsCheckRateCounter = 0;
 let hasAppliedFirstRun = false;
 
+function isVisible(element) {
+    // DOM Element visibility isn't supported in all browsers
+    // https://caniuse.com/mdn-api_element_checkvisibility
+    if (typeof element.checkVisibility != "undefined") {
+        return element.checkVisibility();
+    } else {
+        return !(element.offsetParent === null);
+    }
+}
+
 function backendLoopUpdate() {
     let loading = countBackendsByStatus('loading') + countBackendsByStatus('waiting');
-    if (loading > 0 || backendsListView.checkVisibility()) { // TODO: Safari is apparently dumb about 'checkVisibility'? Test and fix.
+
+    if (loading > 0 || !isVisible(backendsListView)) {
         if (backendsCheckRateCounter++ % 5 == 0) {
             loadBackendsList(); // TODO: only if have permission
         }


### PR DESCRIPTION
As noted in the TODO this wasn't working on Safari because it used the not 100% supported (Safari, IE, Samsung) Element visibility DOM API. https://caniuse.com/mdn-api_element_checkvisibility

We can always switch to it if/when Safari is back in the fold but it's not a very tricky check anyway.

I used https://stackoverflow.com/a/21696585/385622 as a reference, caveat being it can mistakenly count `position: fixed` elements as being invisible (because they don't have an `offsetParent`).

That doesn't curently apply to the `backends_list` element here, but it's good to keep in mind.

Demo on Firefox, Chrome, and Safari for macOS: 


https://github.com/Stability-AI/StableSwarmUI/assets/65950/109545b4-e76c-4b9c-bad6-28e8f4263295

