### PR TITLE
Fix placeholder showing up in popup instead of output

### DIFF
--- a/src/wwwroot/js/genpage.js
+++ b/src/wwwroot/js/genpage.js
@@ -268,7 +268,7 @@ function doGenerate(input_overrides = {}) {
                     let imgHolder = images[data.batch_index];
                     let curImgElem = document.getElementById('current_image_img');
                     if (curImgElem && curImgElem.dataset.batch_id == data.batch_index) {
-                        curImgElem.src = data.image;
+                        setCurrentImage(data.image, data.metadata, data.batch_index)
                     }
                     imgHolder.div.querySelector('img').src = data.image;
                     imgHolder.image = data.image;


### PR DESCRIPTION
Fixes #55

Before: 

![](https://user-images.githubusercontent.com/65950/260172029-3a70d16d-5674-44a3-bfaa-9a43ef0edee6.png)

After:

<img width="1352" alt="image" src="https://github.com/Stability-AI/StableSwarmUI/assets/65950/63aeeb45-a546-478d-93c1-ab57391fc46b">

Directly assigning the image source didn't update is onClick event handler which dynamically assigns the image src before toggling the pop. Might be good to change that in the future maybe but in the meantime this means people can click on the output and see the image, not the placeholder.