### PR TITLE
Update main.js - better indication of current status.

### DIFF
--- a/src/wwwroot/js/genpage/main.js
+++ b/src/wwwroot/js/genpage/main.js
@@ -255,9 +255,9 @@ function updateCurrentStatusDirect(data) {
         if (num == 0) {
             return '';
         }
-        return `<span class="interrupt-line-part">${num} ${text.replaceAll('%', autoS(num))},</span> `;
+        return `<span class="interrupt-line-part">${num} ${text.replaceAll('%', autoS(num))}.</span> `;
     }
-    elem.innerHTML = total == 0 ? '' : `${autoBlock(num_current_gens, 'current generation%')}${autoBlock(num_live_gens, 'running')}${autoBlock(num_backends_waiting, 'queued')}${autoBlock(num_models_loading, 'waiting on model load')} ...`;
+    elem.innerHTML = total == 0 ? '' : `${autoBlock(num_current_gens, 'current generation%')}${autoBlock(num_live_gens, 'running')}${autoBlock(num_backends_waiting, 'queued')}${autoBlock(num_models_loading, 'waiting on model load')} `;
 }
 
 let doesHaveGenCountUpdateQueued = false;


### PR DESCRIPTION
Change comma separation to period, and remove ambiguous ellipsis.

Existing implementation shows:

> 3 current generations, 2 running, 1 queued, ...

This would change it to show:

> 3 current generations. 2 running. 1 queued.

Why?  Because the trailing ellipsis (`...`), especially on smaller windows or screens, indicates that there's additional information to be displayed.  Progress is already indicated by the progress bars on the image placeholder, in addition to the status text disappearing, and would be better served by an animation or spinner if necessary.