### PR TITLE
Fix recursion issue in install-windows.bat

### DIFF
--- a/install-windows.bat
+++ b/install-windows.bat
@@ -8,6 +8,12 @@ if exist StableSwarmUI (
     exit
 )
 
+if exist StableSwarmUI.sln (
+    echo StableSwarmUI is already installed in this folder. If this is incorrect, delete 'StableSwarmUI.sln' and try again.
+    pause
+    exit
+)
+
 winget install Microsoft.DotNet.SDK.7 --accept-source-agreements --accept-package-agreements
 winget install --id Git.Git -e --source winget --accept-source-agreements --accept-package-agreements
 

--- a/install-windows.bat
+++ b/install-windows.bat
@@ -3,7 +3,7 @@
 cd "%~dp0"
 
 if exist StableSwarmUI (
-    echo "StableSwarmUI already installed in this folder. If this is incorrect, delete the 'StableSwarmUI' folder and try again."
+    echo StableSwarmUI is already installed in this folder. If this is incorrect, delete the 'StableSwarmUI' folder and try again.
     pause
     exit
 )


### PR DESCRIPTION
As it is, if a user follows `README.md` and downloads `install-windows.bat` and runs it, it will install StabilitySwarmUI by cloning the repository into a new subdirectory called _StableSwarmUI_.

**This can lead to a recursive issue if the user isn't paying attention**: `install-windows.bat` will now exist within the newly cloned directory as well, and if launched will clone *another* copy into a new _StableSwarmUI_ directory within the existing directory.

This PR does two things: it removes the quotation marks (`echo` will just print those out too), and it checks for `StableSwarmUI.sln` - which would typically only exist in an existing clone/checkout or a manual download of the repository.

Another solution could be to check if `%~dp0` == StabilitySwarmUI (not recommended), or check the .git folder, but this works for the current implementation and follows the batch file's existing behavior.