### PR TITLE
pre- install check for venv on Linux

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -30,5 +30,24 @@ chmod +x dotnet-install.sh
 ./dotnet-install.sh --channel 8.0
 cd ..
 
+
+# Ensure we have python, AND venv installed
+python=`which python ||which python3`
+if [ "$python" == "" ] ; then echo ERROR: cannot find python; exit 1; fi
+#pip=`which pip`
+# Would check for pip, but things work on ubuntu22 even without a
+# visible 'pip' program
+venv=`$python -m venv 2>&1`
+case $venv in
+    *usage*)
+        :
+    ;;
+    *)
+        echo ERROR: python venv is not installed
+        echo You may need to do: sudo apt install python3-venv
+        exit 1
+    ;;
+esac
+
 # Launch
 ./launch-linux.sh $@


### PR DESCRIPTION
Second time I ran into the lack of "do you actually have venv?" 
The install continues like nothing is wrong, but bombs out with user-confusing errors down the road.
So here's something to stop other people from suffering the same fate.

Probably would be good to have an additional check in the actual call to venv, but I guess thats buried in some dotnet code somewhere? I dont deal with that stuff.
