### PR TITLE
add docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  stableswarmui:
+    image: stableswarmui
+    build: .
+    container_name: stableswarmui
+    # uncomment `networks: host` if you want to access other services on the host network (eg a separated comfy instance)
+    # networks: host
+    volumes:
+      - swarmdata:/Data
+      - swarmbackend:/dlbackend
+      - ./Models:/Models
+      - ./Output:/Output
+    ports:
+      - "7801:7801"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              # change the count to the number of GPUs you want to use.
+              count: 1
+              capabilities: [gpu]
+volumes:
+  swarmdata:
+  swarmbackend:


### PR DESCRIPTION
Hey! 

The PR does as the title says, it adds a docker compose. It's a bit easier to work with than with pure docker commands, i.e. for rebuilding and similar - that said maybe there's a reason you left it out.

In any case, I made one for myself and thought I could just as well make a PR in case you're interested. The only thing that's different is that you have to specifiy the number of GPUs. I couldn't find a way to say "all" like in the docker CLI. Just omitting the number does not work. 

Otherwise it does the same.