### PR TITLE
add controlnet preprocessor dependencies in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim
 RUN apt update
 RUN apt install -y git wget build-essential python3.11 python3.11-venv
 
+# Install dependencies for controlnet preprocessors
+RUN apt install -y libglib2.0-0 libgl1
+
 # Copy swarm's files into the docker container
 COPY . .
 


### PR DESCRIPTION
When installing the controlnet preprocessors in Docker, I get the following error:

```
ImportError: libGL.so.1: cannot open shared object file: No such file or directory
```

After installing the necessary dependency, I get:

```
ImportError: libgthread-2.0.so.0: cannot open shared object file: No such file or directory
```

I forgot to look up which Python dependency it was - could it have been OpenCV? A [stack overflow thread](https://stackoverflow.com/questions/55313610/importerror-libgl-so-1-cannot-open-shared-object-file-no-such-file-or-directo) mentions it in relation to libGL.

In any case, adding these to the docker image and restarting with `docker-compose up --build` fixes it and the preprocessors install flawlessly! :)
