### PR TITLE
Fix insightface installation issue in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim
 
 # Install python
 RUN apt update
-RUN apt install -y git wget build-essential python3.11 python3.11-venv
+RUN apt install -y git wget build-essential python3.11 python3.11-venv python3.11-dev
 
 # Install dependencies for controlnet preprocessors
 RUN apt install -y libglib2.0-0 libgl1


### PR DESCRIPTION
This pull request addresses an issue encountered while installing the insightface package in a Docker container. The installation process was failing with the following error:

`insightface/thirdparty/face3d/mesh/cython/mesh_core_cython.cpp:36:10: fatal error: Python.h: No such file or directory
   36 | #include "Python.h"
      |          ^~~~~~~~~~
compilation terminated.
error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1`

The error indicates that the Python.h header file, which is required for building Python extensions in C/C++, was missing.
To resolve this issue, the Dockerfile has been updated to install the necessary Python development packages. 