### PR TITLE
Created Windows Installer + Nightly Builds

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,0 +1,43 @@
+name: Publish Nightly Release
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # This runs the workflow nightly at midnight UTC
+  workflow_dispatch: # Allows manual triggering of the workflow
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+       
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Run PowerShell script
+        shell: pwsh
+        run: ./nightly_build.ps1
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: nightly-tag-${{ steps.date.outputs.date }}
+          release_name: nightly-release-${{ steps.date.outputs.date }}
+          draft: false
+          prerelease: true
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: .\StableSwarmUI-Installer.exe
+          asset_name: StableSwarmUI-Installer.exe
+          asset_content_type: application/octet-stream

--- a/installer_script.nsi
+++ b/installer_script.nsi
@@ -1,0 +1,84 @@
+# NSIS script to create an installer. command:  makensis.exe /LAUNCH .\installer_script.nsi
+
+# Include Modern UI
+!include "MUI2.nsh"
+
+# Compression method, '/SOLID lzma' takes least space
+# setCompressor /SOLID lzma
+
+!define MUI_ICON "src\wwwroot\favicon.ico"
+!define MUI_UNICON "src\wwwroot\favicon.ico"
+!define UNINSTALLER "uninstaller.exe"
+!define REG_UNINSTALL "Software\Microsoft\Windows\CurrentVersion\Uninstall\StableSwarmUI"
+
+# Define variables
+Name "StableSwarmUI"
+OutFile "StableSwarmUI-Installer.exe"
+# Var FilePath
+
+# Default installation directory
+InstallDir "$PROFILE\StableSwarmUI"
+
+# Request application privileges for Windows Vista and later
+RequestExecutionLevel admin
+
+# Pages
+!insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_LICENSE "LICENSE.txt"
+!insertmacro MUI_PAGE_COMPONENTS
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+
+!insertmacro MUI_UNPAGE_WELCOME
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+!insertmacro MUI_UNPAGE_FINISH
+
+!insertmacro MUI_LANGUAGE "English" # The first language is the default language
+
+# Sections
+Section "StableSwarmUI (required)"
+    SetOutPath "$INSTDIR"
+    # Add files to be installed
+    File /r /x *.bat /x *.sh /x *.ps1 /x StableSwarmUI-Installer.exe /x DOCKERFILE /x .dockerignore \
+    /x docker-compose.yml /x colab /x .github /x .git /x bin ${__FILEDIR__}\*.*
+
+    # Register with Windows Installer (Control Panel Add/Remove Programs)
+
+    WriteRegStr HKLM64 "${REG_UNINSTALL}" "DisplayName" "StableSwarmUI"
+    # sets the uninstall string
+    WriteRegStr HKLM64 "${REG_UNINSTALL}" "UninstallString" "$\"$INSTDIR\${UNINSTALLER}$\""
+    WriteRegStr HKLM64 "${REG_UNINSTALL}" "InstallLocation" "$INSTDIR"
+    WriteRegStr HKLM64 "${REG_UNINSTALL}" "DisplayIcon" "$INSTDIR\src\wwwroot\favicon.ico"
+    # Name of the publisher in add or remove programs in control panel TODO: change to proper name
+    WriteRegStr HKLM64 "${REG_UNINSTALL}" "Publisher" "Nirmal Senthilkumar"
+    # Link to the github TODO: change to new github
+    WriteRegStr HKLM64 "${REG_UNINSTALL}" "HelpLink" "https://github.com/nirmie/StableSwarmUI-EXE"
+    # version
+    WriteRegStr HKLM64 "${REG_UNINSTALL}" "DisplayVersion" "1.0.0"
+
+    WriteUninstaller "$INSTDIR\${UNINSTALLER}"
+SectionEnd
+
+# Create Start Menu shortcut
+Section "Start Menu Shortcut"
+    CreateDirectory "$SMPROGRAMS\StableSwarmUI"
+    CreateShortCut "$SMPROGRAMS\StableSwarmUI\StableSwarmUI.lnk" "$INSTDIR\StableSwarmUI.exe" "" "" 0
+SectionEnd
+
+# Uninstaller
+Section "Uninstall"
+    # Delete the installed files
+    Delete "$INSTDIR\*.*"
+    # Remove uninstaller
+    Delete "$INSTDIR\${UNINSTALLER}"
+    # Remove Start Menu shortcut
+    Delete "$SMPROGRAMS\StableSwarmUI\StableSwarmUI.lnk"
+    # Remove installation directory
+    RMDir /r "$INSTDIR\"
+    # Remove Start Menu directory if it's empty
+    RMDir "$SMPROGRAMS\StableSwarmUI"
+    # Remove registry keys
+    DeleteRegKey HKLM64 "${REG_UNINSTALL}"
+SectionEnd

--- a/nightly_build.ps1
+++ b/nightly_build.ps1
@@ -1,0 +1,52 @@
+# Ensure correct local path.
+Set-Location -Path $PSScriptRoot
+
+# Microsoft borked the dotnet installer/path handler, so force x64 to be read first
+$env:PATH = "C:\Program Files\dotnet;$env:PATH"
+
+if (!(Test-Path .git)) {
+    Write-Host "" 
+    Write-Host "WARNING: YOU DID NOT CLONE FROM GIT. THIS WILL BREAK SOME SYSTEMS. PLEASE INSTALL PER THE README."
+    Write-Host "" 
+} else {
+    $CUR_HEAD = git rev-parse HEAD
+    if (!(Test-Path src\bin\last_build)) {
+        $BUILT_HEAD = 0
+    } else {
+        $BUILT_HEAD = Get-Content src\bin\last_build
+    }
+    if ($CUR_HEAD -ne $BUILT_HEAD) {
+        Write-Host ""
+        Write-Host "WARNING: You did a git pull without building. Will now build for you..."
+        Write-Host ""
+        if (Test-Path .\src\bin\live_release_backup) {
+            Remove-Item -Path .\src\bin\live_release_backup -Recurse -Force
+        }
+        if (Test-Path .\src\bin\live_release_backup) {
+            Move-Item -Path .\src\bin\live_release -Destination .\src\bin\live_release_backup
+        }
+    }
+}
+
+# Build the program if it isn't already built
+if (!(Test-Path src\bin\live_release\StableSwarmUI.dll)) {
+    # For some reason Microsoft's nonsense is missing the official nuget source? So forcibly add that to be safe.
+    dotnet nuget add source https://api.nuget.org/v3/index.json --name "NuGet official package source"
+
+    dotnet publish src/StableSwarmUI.csproj -c Release -r win-x64 -o .\ -p:PublishSingleFile=true --self-contained true
+
+    $CUR_HEAD2 = git rev-parse HEAD
+    if (Test-Path src/bin/last_build) {
+        $CUR_HEAD2 | Out-File -FilePath src/bin/last_build
+    }
+}
+
+# Default env configuration, gets overwritten by the C# code's settings handler
+$env:ASPNETCORE_ENVIRONMENT = "Production"
+$env:ASPNETCORE_URLS = "http://*:7801"
+
+makensis.exe installer_script.nsi 
+
+if ($LASTEXITCODE -ne 0) { 
+    Read-Host -Prompt "Press Enter to continue..." 
+}


### PR DESCRIPTION
Created two scripts, a powershell script and nsis script, that work to compile the StableSwarmUI visual studio project into an exe and package it into an installer using NSIS. Also created a GitHub workflow to create a new nightly release every night, but the release portions of the workflow can be adjusted if you only wish to have a new build every week or so. (Can be deleted if unnecessary) 

The installer comes with an uninstaller, registers it with Control Panel, and shares the same icon and Licensing as the original project. 

Please let me know if I need to make any changes before it can be merged.