### PR TITLE
#Civitai - Add basic Civitai API Key authentication support.

### DIFF
--- a/docs/APIRoutes/BasicAPIFeatures.md
+++ b/docs/APIRoutes/BasicAPIFeatures.md
@@ -15,12 +15,14 @@ Basic general API routes, primarily for users and session handling.
 - HTTP Route [GetMyUserData](#http-route-apigetmyuserdata)
 - HTTP Route [GetNewSession](#http-route-apigetnewsession)
 - HTTP Route [GetStabilityAPIKeyStatus](#http-route-apigetstabilityapikeystatus)
+- HTTP Route [GetCivitaiAPIKeyStatus](#http-route-apigetcivitaiapikeystatus)
 - HTTP Route [GetUserSettings](#http-route-apigetusersettings)
 - WebSocket Route [InstallConfirmWS](#websocket-route-apiinstallconfirmws)
 - HTTP Route [InterruptAll](#http-route-apiinterruptall)
 - HTTP Route [ServerDebugMessage](#http-route-apiserverdebugmessage)
 - HTTP Route [SetParamEdits](#http-route-apisetparamedits)
 - HTTP Route [SetStabilityAPIKey](#http-route-apisetstabilityapikey)
+- HTTP Route [SetCivitaiAPIKey](#http-route-apisetcivitaiapikey)
 
 ## HTTP Route /API/AddNewPreset
 
@@ -185,6 +187,22 @@ Basic general API routes, primarily for users and session handling.
 (RETURN INFO NOT SET)
 ```
 
+## HTTP Route /API/GetCivitaiAPIKeyStatus
+
+#### Description
+
+(ROUTE DESCRIPTION NOT SET)
+
+#### Parameters
+
+**None.**
+
+#### Return Format
+
+```js
+(RETURN INFO NOT SET)
+```
+
 ## HTTP Route /API/GetUserSettings
 
 #### Description
@@ -280,6 +298,24 @@ Basic general API routes, primarily for users and session handling.
 ```
 
 ## HTTP Route /API/SetStabilityAPIKey
+
+#### Description
+
+(ROUTE DESCRIPTION NOT SET)
+
+#### Parameters
+
+| Name | Type | Description | Default |
+| --- | --- | --- | --- |
+| key | String | (PARAMETER DESCRIPTION NOT SET) | **(REQUIRED)** |
+
+#### Return Format
+
+```js
+(RETURN INFO NOT SET)
+```
+
+## HTTP Route /API/SetCivitaiAPIKey
 
 #### Description
 

--- a/docs/APIRoutes/BasicAPIFeatures.md
+++ b/docs/APIRoutes/BasicAPIFeatures.md
@@ -14,15 +14,13 @@ Basic general API routes, primarily for users and session handling.
 - HTTP Route [GetLanguage](#http-route-apigetlanguage)
 - HTTP Route [GetMyUserData](#http-route-apigetmyuserdata)
 - HTTP Route [GetNewSession](#http-route-apigetnewsession)
-- HTTP Route [GetStabilityAPIKeyStatus](#http-route-apigetstabilityapikeystatus)
-- HTTP Route [GetCivitaiAPIKeyStatus](#http-route-apigetcivitaiapikeystatus)
+- HTTP Route [GetAPIKeyStatus](#http-route-apigetstabilityapikeystatus)
 - HTTP Route [GetUserSettings](#http-route-apigetusersettings)
 - WebSocket Route [InstallConfirmWS](#websocket-route-apiinstallconfirmws)
 - HTTP Route [InterruptAll](#http-route-apiinterruptall)
 - HTTP Route [ServerDebugMessage](#http-route-apiserverdebugmessage)
 - HTTP Route [SetParamEdits](#http-route-apisetparamedits)
-- HTTP Route [SetStabilityAPIKey](#http-route-apisetstabilityapikey)
-- HTTP Route [SetCivitaiAPIKey](#http-route-apisetcivitaiapikey)
+- HTTP Route [SetAPIKey](#http-route-apisetstabilityapikey)
 
 ## HTTP Route /API/AddNewPreset
 
@@ -171,23 +169,7 @@ Basic general API routes, primarily for users and session handling.
 (RETURN INFO NOT SET)
 ```
 
-## HTTP Route /API/GetStabilityAPIKeyStatus
-
-#### Description
-
-(ROUTE DESCRIPTION NOT SET)
-
-#### Parameters
-
-**None.**
-
-#### Return Format
-
-```js
-(RETURN INFO NOT SET)
-```
-
-## HTTP Route /API/GetCivitaiAPIKeyStatus
+## HTTP Route /API/GetAPIKeyStatus
 
 #### Description
 
@@ -297,7 +279,7 @@ Basic general API routes, primarily for users and session handling.
 (RETURN INFO NOT SET)
 ```
 
-## HTTP Route /API/SetStabilityAPIKey
+## HTTP Route /API/SetAPIKey
 
 #### Description
 
@@ -314,22 +296,3 @@ Basic general API routes, primarily for users and session handling.
 ```js
 (RETURN INFO NOT SET)
 ```
-
-## HTTP Route /API/SetCivitaiAPIKey
-
-#### Description
-
-(ROUTE DESCRIPTION NOT SET)
-
-#### Parameters
-
-| Name | Type | Description | Default |
-| --- | --- | --- | --- |
-| key | String | (PARAMETER DESCRIPTION NOT SET) | **(REQUIRED)** |
-
-#### Return Format
-
-```js
-(RETURN INFO NOT SET)
-```
-

--- a/src/Pages/Text2Image.cshtml
+++ b/src/Pages/Text2Image.cshtml
@@ -599,7 +599,7 @@
     <div class="tab-pane tab-pane-vw" id="user_tab" role="tabpanel">
         <ul class="nav nav-tabs" role="tablist" id="usertablist">
             <li class="nav-item" role="presentation">
-                <a class="nav-link active translate" data-bs-toggle="tab" href="#user-info" aria-selected="true" role="tab">User Info</a>
+                <a class="nav-link active translate" data-bs-toggle="tab" href="#user-info" id="userinfotabbutton" aria-selected="true" role="tab">User Info</a>
             </li>
             <li class="nav-item" role="presentation">
                 <a class="nav-link translate" data-bs-toggle="tab" href="#Settings-User" id="userconfigtabbutton" aria-selected="false" tabindex="-1" role="tab">User Settings</a>
@@ -624,6 +624,22 @@
                             <button class="basic-button translate" id="stability_key_submit" onclick="stabilityAPIHelper.onSaveButton()" disabled>Save</button>
                             <button class="basic-button translate" id="stability_key_remove" onclick="stabilityAPIHelper.onRemoveButton()" disabled>Remove</button>
                             <br>Your key: <span id="stability_key_status">(Unknown)</span>
+                        </p>
+                    </div>
+                </div>
+                <div class="card border-secondary mb-3 card-center-container">
+                    <div class="card-header translate">Civitai API Key</div>
+                    <div class="card-body">
+                        <p class="card-text translate">
+                            If you plan to use the <a href="#" onclick="getRequiredElementById('utilitiestabbutton').click();getRequiredElementById('modeldownloadertabbutton').click();">Model Downloader</a> utility to download content from <a href="https://civitai.com/" target="_blank" rel="noreferrer noopener">Civitai</a>, you should set your Civitai API key below.<br />
+                            This will allow you to download gated or early-access content that your Civitai account has access to.<br />
+                            You can create an API key <a href="https://civitai.com/user/account" target="_blank" rel="noreferrer noopener">here</a>.<br />
+                            <br />
+                            Once you have your API key, enter it below and click save:<br />
+                            <input type="text" id="civitai_api_key" placeholder="Civitai API Key" autocomplete="off" oninput="civitaiAPIHelper.onKeyInput()" />
+                            <button class="basic-button translate" id="civitai_key_submit" onclick="civitaiAPIHelper.onSaveButton()" disabled>Save</button>
+                            <button class="basic-button translate" id="civitai_key_remove" onclick="civitaiAPIHelper.onRemoveButton()" disabled>Remove</button><br />
+                            Your key: <span id="civitai_key_status">(Unknown)</span><br />
                         </p>
                     </div>
                 </div>

--- a/src/Pages/Text2Image.cshtml
+++ b/src/Pages/Text2Image.cshtml
@@ -631,15 +631,15 @@
                     <div class="card-header translate">Civitai API Key</div>
                     <div class="card-body">
                         <p class="card-text translate">
-                            If you plan to use the <a href="#" onclick="getRequiredElementById('utilitiestabbutton').click();getRequiredElementById('modeldownloadertabbutton').click();">Model Downloader</a> utility to download content from <a href="https://civitai.com/" target="_blank" rel="noreferrer noopener">Civitai</a>, you should set your Civitai API key below.<br />
-                            This will allow you to download gated or early-access content that your Civitai account has access to.<br />
-                            You can create an API key <a href="https://civitai.com/user/account" target="_blank" rel="noreferrer noopener">here</a>.<br />
-                            <br />
-                            Once you have your API key, enter it below and click save:<br />
-                            <input type="text" id="civitai_api_key" placeholder="Civitai API Key" autocomplete="off" oninput="civitaiAPIHelper.onKeyInput()" />
+                            If you plan to use the <a href="#" onclick="getRequiredElementById('utilitiestabbutton').click();getRequiredElementById('modeldownloadertabbutton').click();">Model Downloader</a> utility to download content from <a href="https://civitai.com/" target="_blank" rel="noreferrer noopener">Civitai</a>, you might want to set your Civitai API key below.
+                            <br>This will allow you to download gated or early-access content that your Civitai account has access to.
+                            <br>You can create an API key <a href="https://civitai.com/user/account" target="_blank" rel="noreferrer noopener">here</a>.
+                            <br>
+                            <br>Once you have your API key, enter it below and click save:
+                            <br><input type="text" id="civitai_api_key" placeholder="Civitai API Key" autocomplete="off" oninput="civitaiAPIHelper.onKeyInput()" />
                             <button class="basic-button translate" id="civitai_key_submit" onclick="civitaiAPIHelper.onSaveButton()" disabled>Save</button>
-                            <button class="basic-button translate" id="civitai_key_remove" onclick="civitaiAPIHelper.onRemoveButton()" disabled>Remove</button><br />
-                            Your key: <span id="civitai_key_status">(Unknown)</span><br />
+                            <button class="basic-button translate" id="civitai_key_remove" onclick="civitaiAPIHelper.onRemoveButton()" disabled>Remove</button>
+                            <br>Your key: <span id="civitai_key_status">(Unknown)</span>
                         </p>
                     </div>
                 </div>

--- a/src/WebAPI/ModelsAPI.cs
+++ b/src/WebAPI/ModelsAPI.cs
@@ -481,45 +481,20 @@ public static class ModelsAPI
         {
             return new JObject() { ["error"] = "Invalid type." };
         }
-
-        // Only auto-inject civitai token on HTTPS requests to (help) prevent leaking API keys over the network
-        if (url.StartsWith("https://"))
+        string originalUrl = url;
+        url = url.Before('#');
+        if (url.StartsWith("https://civitai.com/"))
         {
-            // Example (valid) full URL format: https://example-sub.domain.example.org:80/Example/Page.html?Query1=Text&Query2=MoreText#Wow,A,Page?Wild
-
-            // Check for the civitai domain
-            string domainName = url.After("//").Before('/').Before(':').ToLower();
-            if (domainName == "civitai.com")
+            string civitaiApiKey = session.User.GetGenericData("civitai_api", "key");
+            if (!string.IsNullOrEmpty(civitaiApiKey))
             {
-                // Check that we have a civitai api key set
-                string civitaiApiKey = session.User.GetGenericData("civitai_api", "key");
-                if (!string.IsNullOrEmpty(civitaiApiKey))
+                if (!url.Contains("?token=") && !url.Contains("&token="))
                 {
-                    // Check if our URL has a Fragment (a '#' and optionally some text), as we need to append our token to the query params _before_ that
-                    bool urlHasFragment = url.Contains('#');
-                    string fragment = "";
-                    string domainPathAndQuery = urlHasFragment ? url.BeforeAndAfter('#', out fragment) : url; 
-
-                    // Check that our query params don't already have a API key set
-                    if (!domainPathAndQuery.Contains("?token=") && !domainPathAndQuery.Contains("&token="))
-                    {
-                        // We have a Secure Request to Civitai, we have an API key set, and there is not already an API key on the URL. We should now add our API Key into the original URL's query parameter list.
-
-                        // If there's already query parameters, we append &token=TOKEN, otherwise we start them by appending ?token=TOKEN
-                        domainPathAndQuery += (domainPathAndQuery.Contains('?') ? "&token=" : "?token=") + civitaiApiKey;
-
-                        // Rebuild our final URL
-                        string newUrl = domainPathAndQuery + (urlHasFragment ? '#' + fragment : "");
-
-                        Logs.Debug($"Added Civitai API Key to download request. Original URL: {url}");
-
-                        // Finally replace our URL
-                        url = newUrl;
-                    }
+                    url += (url.Contains('?') ? "&token=" : "?token=") + civitaiApiKey;
+                    Logs.Debug($"Added Civitai API Key to download request. Original URL: {originalUrl}");
                 }
             }
         }
-
         try
         {
             string outPath = $"{handler.FolderPaths[0]}/{name}.safetensors";
@@ -539,7 +514,7 @@ public static class ModelsAPI
                     ["current_percent"] = progress / (double)total,
                     ["overall_percent"] = 0.2
                 }, API.WebsocketTimeout);
-            });
+            }, originalUrl);
             File.Move(tempPath, outPath);
             if (!string.IsNullOrWhiteSpace(metadata))
             {

--- a/src/wwwroot/js/genpage/usertab.js
+++ b/src/wwwroot/js/genpage/usertab.js
@@ -1,27 +1,10 @@
-
-class ApiKeyType {
-    constructor(apiName) {
-        this.apiName = apiName.toLowerCase();
-    }
-
-    /** Gets the name in a 'lowercase' format */
-    get nameForForm() {
-        return this.apiName;
-    }
-
-    /** Gets the name in a 'Capitalized' format */
-    get nameForEndpoint() {
-        return this.apiName.charAt(0).toUpperCase() + this.apiName.slice(1);
-    }
-}
-
 class APIKeyHelper {
-    constructor(apiKeyType) {
-        this.apiKeyType = apiKeyType;
-        this.keyInput = getRequiredElementById(this.apiKeyType.nameForForm + '_api_key');
-        this.keySubmit = getRequiredElementById(this.apiKeyType.nameForForm + '_key_submit');
-        this.keyRemove = getRequiredElementById(this.apiKeyType.nameForForm + '_key_remove');
-        this.keyStatus = getRequiredElementById(this.apiKeyType.nameForForm + '_key_status');
+    constructor(keyType, prefix) {
+        this.keyType = keyType;
+        this.keyInput = getRequiredElementById(`${prefix}_api_key`);
+        this.keySubmit = getRequiredElementById(`${prefix}_key_submit`);
+        this.keyRemove = getRequiredElementById(`${prefix}_key_remove`);
+        this.keyStatus = getRequiredElementById(`${prefix}_key_status`);
     }
 
     onKeyInput() {
@@ -30,46 +13,33 @@ class APIKeyHelper {
     }
 
     onSaveButton() {
-        let newApikey = this.keyInput.value;
-        if (!newApikey) {
+        let key = this.keyInput.value;
+        if (!key) {
             alert('Please enter a key');
             return;
         }
         this.keySubmit.disabled = true;
-        genericRequest('Set' + this.apiKeyType.nameForEndpoint + 'APIKey', { key: newApikey }, data => {
-            // If we successfully wrote the API key, remove the value from the form immediately to hide it.
-            if ("success" in data && data.success === true) {
-                this.keyInput.value = "";
-                this.keyStatus.innerText = "Updated!";
-                this.keyRemove.disabled = false;
-            } else {
-                this.updateStatus();
-            }
+        genericRequest('SetAPIKey', { keyType: this.keyType, key: key }, data => {
+            this.updateStatus();
         });
     }
 
     onRemoveButton() {
-        genericRequest('Set' + this.apiKeyType.nameForEndpoint + 'APIKey', { key: null }, data => {
-            // If we successfully cleared our API key, disable the remove button
-            if ("success" in data && data.success === true) {
-                this.keyStatus.innerText = "(Unset)";
-                this.keyRemove.disabled = true;
-            } else {
-                this.updateStatus();
-            }
+        genericRequest('SetAPIKey', { keyType: this.keyType, key: 'none' }, data => {
+            this.updateStatus();
         });
     }
 
     updateStatus() {
-        genericRequest('Get' + this.apiKeyType.nameForEndpoint + 'APIKeyStatus', {}, data => {
+        genericRequest('GetAPIKeyStatus', { keyType: this.keyType }, data => {
             this.keyStatus.innerText = data.status;
-            this.keyRemove.disabled = data.status == '(Unset)' || data.status == '(Unknown)';
+            this.keyRemove.disabled = data.status == 'not set';
         });
     }
 }
 
-stabilityAPIHelper = new APIKeyHelper(new ApiKeyType('stability'));
-civitaiAPIHelper = new APIKeyHelper(new ApiKeyType('civitai'));
+stabilityAPIHelper = new APIKeyHelper('stability_api', 'stability');
+civitaiAPIHelper = new APIKeyHelper('civitai_api', 'civitai');
 
 getRequiredElementById('usersettingstabbutton').addEventListener('click', () => {
     stabilityAPIHelper.updateStatus();

--- a/src/wwwroot/js/genpage/usertab.js
+++ b/src/wwwroot/js/genpage/usertab.js
@@ -1,10 +1,27 @@
 
-class StabilityAPIHelper {
-    constructor() {
-        this.keyInput = getRequiredElementById('stability_api_key');
-        this.keySubmit = getRequiredElementById('stability_key_submit');
-        this.keyRemove = getRequiredElementById('stability_key_remove');
-        this.keyStatus = getRequiredElementById('stability_key_status');
+class ApiKeyType {
+    constructor(apiName) {
+        this.apiName = apiName.toLowerCase();
+    }
+
+    /** Gets the name in a 'lowercase' format */
+    get nameForForm() {
+        return this.apiName;
+    }
+
+    /** Gets the name in a 'Capitalized' format */
+    get nameForEndpoint() {
+        return this.apiName.charAt(0).toUpperCase() + this.apiName.slice(1);
+    }
+}
+
+class APIKeyHelper {
+    constructor(apiKeyType) {
+        this.apiKeyType = apiKeyType;
+        this.keyInput = getRequiredElementById(this.apiKeyType.nameForForm + '_api_key');
+        this.keySubmit = getRequiredElementById(this.apiKeyType.nameForForm + '_key_submit');
+        this.keyRemove = getRequiredElementById(this.apiKeyType.nameForForm + '_key_remove');
+        this.keyStatus = getRequiredElementById(this.apiKeyType.nameForForm + '_key_status');
     }
 
     onKeyInput() {
@@ -13,32 +30,48 @@ class StabilityAPIHelper {
     }
 
     onSaveButton() {
-        let key = this.keyInput.value;
-        if (!key) {
+        let newApikey = this.keyInput.value;
+        if (!newApikey) {
             alert('Please enter a key');
             return;
         }
         this.keySubmit.disabled = true;
-        genericRequest('SetStabilityAPIKey', { key: key }, data => {
-            this.updateStatus();
+        genericRequest('Set' + this.apiKeyType.nameForEndpoint + 'APIKey', { key: newApikey }, data => {
+            // If we successfully wrote the API key, remove the value from the form immediately to hide it.
+            if ("success" in data && data.success === true) {
+                this.keyInput.value = "";
+                this.keyStatus.innerText = "Updated!";
+                this.keyRemove.disabled = false;
+            } else {
+                this.updateStatus();
+            }
         });
     }
 
     onRemoveButton() {
-        genericRequest('SetStabilityAPIKey', { key: 'none' }, data => {
-            this.updateStatus();
+        genericRequest('Set' + this.apiKeyType.nameForEndpoint + 'APIKey', { key: null }, data => {
+            // If we successfully cleared our API key, disable the remove button
+            if ("success" in data && data.success === true) {
+                this.keyStatus.innerText = "(Unset)";
+                this.keyRemove.disabled = true;
+            } else {
+                this.updateStatus();
+            }
         });
     }
 
     updateStatus() {
-        genericRequest('GetStabilityAPIKeyStatus', {}, data => {
+        genericRequest('Get' + this.apiKeyType.nameForEndpoint + 'APIKeyStatus', {}, data => {
             this.keyStatus.innerText = data.status;
-            this.keyRemove.disabled = data.status == 'not set';
+            this.keyRemove.disabled = data.status == '(Unset)' || data.status == '(Unknown)';
         });
     }
 }
 
-stabilityAPIHelper = new StabilityAPIHelper();
+stabilityAPIHelper = new APIKeyHelper(new ApiKeyType('stability'));
+civitaiAPIHelper = new APIKeyHelper(new ApiKeyType('civitai'));
 
-
-getRequiredElementById('usersettingstabbutton').addEventListener('click', () => stabilityAPIHelper.updateStatus());
+getRequiredElementById('usersettingstabbutton').addEventListener('click', () => {
+    stabilityAPIHelper.updateStatus();
+    civitaiAPIHelper.updateStatus();
+});

--- a/src/wwwroot/js/genpage/utiltab.js
+++ b/src/wwwroot/js/genpage/utiltab.js
@@ -427,7 +427,7 @@ class ModelDownloaderUtil {
                 current.style.width = `0%`;
             }
         }, 0, e => {
-            this.textArea.innerHTML = `Error: ${escapeHtml(e)}\n<br>Are you sure the URL is correct? Note some models may require you to be logged in, which is incompatible with an auto-downloader.`;
+            this.textArea.innerHTML = `Error: ${escapeHtml(e)}\n<br>Are you sure the URL is correct? Note some models may require you to authenticate using an <a href="#" onclick="getRequiredElementById('usersettingstabbutton').click();getRequiredElementById('userinfotabbutton').click();">API Key</a>.`;
             overall.style.width = `0%`;
             current.style.width = `0%`;
         });


### PR DESCRIPTION
- Adds a new Civitai API Key manager on the user info page.
- Users can now set their Civitai API keys to be automatically used by the model downloader utility.
- Civitai API Keys are only automatically added to HTTPS requests on civitai-dot-com URLs